### PR TITLE
fix(security): Sanitize plugin ID to prevent path traversal attacks

### DIFF
--- a/src/services/CacheService.ts
+++ b/src/services/CacheService.ts
@@ -46,8 +46,9 @@ export class CacheService extends BaseService {
             cleanupInterval: 5 * 60 * 1000, // 5 minutes
             ...config
         };
-        // Derive the cache file path from plugin ID
-        this.cacheFilePath = `.obsidian/plugins/${pluginId}/cache.json`;
+        // Sanitize plugin ID to prevent path traversal attacks
+        const sanitizedPluginId = this.sanitizePluginId(pluginId);
+        this.cacheFilePath = `.obsidian/plugins/${sanitizedPluginId}/cache.json`;
     }
 
     protected async onInitialize(): Promise<void> {
@@ -381,5 +382,40 @@ export class CacheService extends BaseService {
             size += JSON.stringify(entry).length * 2; // Rough estimate
         }
         return size;
+    }
+
+    /**
+     * Sanitize plugin ID to prevent path traversal attacks
+     * @param pluginId - The plugin ID to sanitize
+     * @returns A sanitized plugin ID safe for file path construction
+     */
+    private sanitizePluginId(pluginId: string): string {
+        if (!pluginId || typeof pluginId !== 'string') {
+            throw new Error('Plugin ID must be a non-empty string');
+        }
+
+        // Remove any path traversal sequences and normalize path separators
+        let sanitized = pluginId
+            .replace(/\.\./g, '')  // Remove ".." sequences
+            .replace(/[\/\\]/g, '-')  // Replace path separators with hyphens
+            .replace(/[^a-zA-Z0-9_-]/g, '')  // Remove any non-alphanumeric characters except underscore and hyphen
+            .toLowerCase();  // Convert to lowercase for consistency
+
+        // Ensure the sanitized ID is not empty and starts with an alphanumeric character
+        if (!sanitized || sanitized.length === 0) {
+            throw new Error('Plugin ID contains only invalid characters');
+        }
+
+        // Ensure it starts with an alphanumeric character
+        if (!/^[a-zA-Z0-9]/.test(sanitized)) {
+            sanitized = 'plugin-' + sanitized;
+        }
+
+        // Limit length to prevent excessively long directory names
+        if (sanitized.length > 50) {
+            sanitized = sanitized.substring(0, 50);
+        }
+
+        return sanitized;
     }
 }

--- a/tests/CacheService.test.ts
+++ b/tests/CacheService.test.ts
@@ -1,0 +1,144 @@
+// tests/CacheService.test.ts
+
+import { CacheService } from '../src/services/CacheService';
+import { ErrorHandlingService } from '../src/services/ErrorHandlingService';
+
+// Mock Obsidian App
+const mockApp = {
+    vault: {
+        adapter: {
+            read: jest.fn(),
+            write: jest.fn(),
+            exists: jest.fn()
+        }
+    }
+} as any;
+
+// Mock ErrorHandlingService
+const mockErrorHandler = {
+    handleError: jest.fn(),
+    executeWithRetry: jest.fn()
+} as any;
+
+describe('CacheService', () => {
+    let cacheService: CacheService;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        // Mock executeWithRetry to just execute the function
+        mockErrorHandler.executeWithRetry.mockImplementation((fn: () => any) => fn());
+        mockApp.vault.adapter.read.mockRejectedValue(new Error('File not found'));
+    });
+
+    describe('Plugin ID Sanitization', () => {
+        test('should sanitize valid plugin ID correctly', () => {
+            cacheService = new CacheService(mockApp, mockErrorHandler, {}, 'retrospect-ai');
+            expect(cacheService['cacheFilePath']).toBe('.obsidian/plugins/retrospect-ai/cache.json');
+        });
+
+        test('should remove path traversal sequences', () => {
+            cacheService = new CacheService(mockApp, mockErrorHandler, {}, '../../../malicious');
+            expect(cacheService['cacheFilePath']).toBe('.obsidian/plugins/malicious/cache.json');
+        });
+
+        test('should replace path separators with hyphens', () => {
+            cacheService = new CacheService(mockApp, mockErrorHandler, {}, 'folder/subfolder\\malicious');
+            expect(cacheService['cacheFilePath']).toBe('.obsidian/plugins/folder-subfolder-malicious/cache.json');
+        });
+
+        test('should remove special characters', () => {
+            cacheService = new CacheService(mockApp, mockErrorHandler, {}, 'plugin@#$%name!');
+            expect(cacheService['cacheFilePath']).toBe('.obsidian/plugins/pluginname/cache.json');
+        });
+
+        test('should convert to lowercase', () => {
+            cacheService = new CacheService(mockApp, mockErrorHandler, {}, 'MyPlugin-NAME');
+            expect(cacheService['cacheFilePath']).toBe('.obsidian/plugins/myplugin-name/cache.json');
+        });
+
+        test('should prepend "plugin-" if it starts with non-alphanumeric', () => {
+            cacheService = new CacheService(mockApp, mockErrorHandler, {}, '-my-plugin');
+            expect(cacheService['cacheFilePath']).toBe('.obsidian/plugins/plugin-my-plugin/cache.json');
+        });
+
+        test('should limit length to 50 characters', () => {
+            const longName = 'a'.repeat(100);
+            cacheService = new CacheService(mockApp, mockErrorHandler, {}, longName);
+            expect(cacheService['cacheFilePath']).toBe('.obsidian/plugins/' + 'a'.repeat(50) + '/cache.json');
+        });
+
+        test('should throw error for empty plugin ID', () => {
+            expect(() => {
+                new CacheService(mockApp, mockErrorHandler, {}, '');
+            }).toThrow('Plugin ID must be a non-empty string');
+        });
+
+        test('should throw error for plugin ID with only invalid characters', () => {
+            expect(() => {
+                new CacheService(mockApp, mockErrorHandler, {}, '!@#$%^&*()');
+            }).toThrow('Plugin ID contains only invalid characters');
+        });
+
+        test('should throw error for non-string plugin ID', () => {
+            expect(() => {
+                new CacheService(mockApp, mockErrorHandler, {}, null as any);
+            }).toThrow('Plugin ID must be a non-empty string');
+        });
+    });
+
+    describe('Cache Operations', () => {
+        beforeEach(() => {
+            cacheService = new CacheService(mockApp, mockErrorHandler, { persistToDisk: false }, 'test-plugin');
+        });
+
+        test('should store and retrieve values', async () => {
+            const testKey = 'test-key';
+            const testValue = { data: 'test-data' };
+
+            await cacheService.set(testKey, testValue);
+            const result = await cacheService.get(testKey);
+
+            expect(result).toEqual(testValue);
+        });
+
+        test('should return null for non-existent key', async () => {
+            const result = await cacheService.get('non-existent-key');
+            expect(result).toBeNull();
+        });
+
+        test('should delete values', async () => {
+            const testKey = 'test-key';
+            const testValue = { data: 'test-data' };
+
+            await cacheService.set(testKey, testValue);
+            const deleted = await cacheService.delete(testKey);
+            const result = await cacheService.get(testKey);
+
+            expect(deleted).toBe(true);
+            expect(result).toBeNull();
+        });
+
+        test('should clear all values', async () => {
+            await cacheService.set('key1', 'value1');
+            await cacheService.set('key2', 'value2');
+            
+            await cacheService.clear();
+            
+            const result1 = await cacheService.get('key1');
+            const result2 = await cacheService.get('key2');
+            
+            expect(result1).toBeNull();
+            expect(result2).toBeNull();
+        });
+
+        test('should check if key exists', async () => {
+            const testKey = 'test-key';
+            const testValue = { data: 'test-data' };
+
+            expect(await cacheService.has(testKey)).toBe(false);
+            
+            await cacheService.set(testKey, testValue);
+            expect(await cacheService.has(testKey)).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
- Added sanitizePluginId() method to CacheService
- Prevents directory traversal attacks (../../../)
- Removes path separators and special characters
- Adds comprehensive test suite for security validation
- Fixes issue where pluginId could be used for path injection

## Summary by Sourcery

Sanitize plugin IDs in CacheService to prevent path traversal and ensure safe file path construction, and add tests for security validation and cache operations

Bug Fixes:
- Prevent directory traversal and path injection via plugin ID when deriving cache file paths

Enhancements:
- Introduce sanitizePluginId method to filter, normalize, and limit plugin IDs
- Apply sanitized plugin ID when constructing cache file paths

Tests:
- Add comprehensive tests covering plugin ID sanitization edge cases and core cache operations