### PR TITLE
feat: add analysis scope settings for journal reflection

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,18 @@ interface JournalReflectionSettings {
 	enableAdvancedNLP?: boolean;
 	nlpAnalysisDepth?: 'basic' | 'moderate' | 'deep';
 	blockerDetectionSensitivity?: 'low' | 'medium' | 'high';
+	// Analysis Scope Settings
+	enabledAnalysisScopes?: boolean;
+	analysisScope?: 'whole-life' | 'work-only' | 'custom';
+	customAnalysisScope?: {
+		name: string;
+		includeKeywords: string[];
+		excludeKeywords: string[];
+		includeFolders: string[];
+		excludeFolders: string[];
+		includeTags: string[];
+		excludeTags: string[];
+	};
 }
 
 const OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
@@ -79,6 +91,18 @@ const DEFAULT_SETTINGS: JournalReflectionSettings = {
 	enableAdvancedNLP: true,
 	nlpAnalysisDepth: 'moderate',
 	blockerDetectionSensitivity: 'medium',
+	// Analysis Scope Settings
+	enabledAnalysisScopes: false,
+	analysisScope: 'whole-life',
+	customAnalysisScope: {
+		name: '',
+		includeKeywords: [],
+		excludeKeywords: [],
+		includeFolders: [],
+		excludeFolders: [],
+		includeTags: [],
+		excludeTags: []
+	}
 };
 
 /**
@@ -231,7 +255,10 @@ export default class JournalReflectionPlugin extends Plugin {
 					daysToInclude: this.settings.daysToInclude,
 					excludePrivate: this.settings.excludePrivate,
 					periodicNoteFolders: this.settings.periodicNoteFolders,
-					reflectionFolder: this.settings.reflectionFolder
+					reflectionFolder: this.settings.reflectionFolder,
+					enabledAnalysisScopes: this.settings.enabledAnalysisScopes,
+					analysisScope: this.settings.analysisScope,
+					customAnalysisScope: this.settings.customAnalysisScope
 				};
 				return new FileOperationsService(this.app, config, errorHandler);
 			},
@@ -345,7 +372,10 @@ export default class JournalReflectionPlugin extends Plugin {
 				daysToInclude: this.settings.daysToInclude,
 				excludePrivate: this.settings.excludePrivate,
 				periodicNoteFolders: this.settings.periodicNoteFolders,
-				reflectionFolder: this.settings.reflectionFolder
+				reflectionFolder: this.settings.reflectionFolder,
+				enabledAnalysisScopes: this.settings.enabledAnalysisScopes,
+				analysisScope: this.settings.analysisScope,
+				customAnalysisScope: this.settings.customAnalysisScope
 			});
 		}
 	}
@@ -1243,8 +1273,194 @@ class JournalReflectionSettingTab extends PluginSettingTab {
 					})
 			);
 
+		// Analysis Scope Section (Feature Flag)
+		if (this.plugin.settings.enabledAnalysisScopes) {
+			containerEl.createEl("h3", { text: "Analysis Scope" });
+
+			// Analysis Scope Selection
+			new Setting(containerEl)
+				.setName("Analysis Scope")
+				.setDesc("Choose the scope of analysis to focus on specific areas of your journal")
+				.addDropdown((dropdown) =>
+					dropdown
+						.addOption("whole-life", "Whole Life - Analyze all entries")
+						.addOption("work-only", "Work Only - Focus on work-related entries")
+						.addOption("custom", "Custom - Define your own scope")
+						.setValue(this.plugin.settings.analysisScope || 'whole-life')
+						.onChange(async (value: 'whole-life' | 'work-only' | 'custom') => {
+							this.plugin.settings.analysisScope = value;
+							await this.plugin.saveSettings();
+							// Refresh to show/hide custom scope settings
+							this.display();
+						})
+				);
+
+			// Custom Scope Settings (only show if custom is selected)
+			if (this.plugin.settings.analysisScope === 'custom') {
+				const customScope = this.plugin.settings.customAnalysisScope || DEFAULT_SETTINGS.customAnalysisScope;
+
+				// Custom Scope Name
+				new Setting(containerEl)
+					.setName("Custom Scope Name")
+					.setDesc("A descriptive name for your custom analysis scope")
+					.addText((text) => {
+						text.setPlaceholder("e.g., Health & Wellness, Creative Projects")
+							.setValue(customScope.name)
+							.onChange(async (value) => {
+								if (!this.plugin.settings.customAnalysisScope) {
+									this.plugin.settings.customAnalysisScope = { ...DEFAULT_SETTINGS.customAnalysisScope };
+								}
+								this.plugin.settings.customAnalysisScope.name = value;
+								await this.plugin.saveSettings();
+							});
+					});
+
+				// Include Keywords
+				new Setting(containerEl)
+					.setName("Include Keywords")
+					.setDesc("Comma-separated keywords to include in analysis (e.g., work, project, meeting)")
+					.addText((text) => {
+						text.setPlaceholder("work, project, meeting, deadline")
+							.setValue(customScope.includeKeywords.join(', '))
+							.onChange(async (value) => {
+								if (!this.plugin.settings.customAnalysisScope) {
+									this.plugin.settings.customAnalysisScope = { ...DEFAULT_SETTINGS.customAnalysisScope };
+								}
+								this.plugin.settings.customAnalysisScope.includeKeywords = value
+									.split(',')
+									.map(k => k.trim())
+									.filter(k => k.length > 0);
+								await this.plugin.saveSettings();
+							});
+					});
+
+				// Exclude Keywords
+				new Setting(containerEl)
+					.setName("Exclude Keywords")
+					.setDesc("Comma-separated keywords to exclude from analysis (e.g., personal, private)")
+					.addText((text) => {
+						text.setPlaceholder("personal, private, family")
+							.setValue(customScope.excludeKeywords.join(', '))
+							.onChange(async (value) => {
+								if (!this.plugin.settings.customAnalysisScope) {
+									this.plugin.settings.customAnalysisScope = { ...DEFAULT_SETTINGS.customAnalysisScope };
+								}
+								this.plugin.settings.customAnalysisScope.excludeKeywords = value
+									.split(',')
+									.map(k => k.trim())
+									.filter(k => k.length > 0);
+								await this.plugin.saveSettings();
+							});
+					});
+
+				// Include Tags
+				new Setting(containerEl)
+					.setName("Include Tags")
+					.setDesc("Comma-separated tags to include in analysis (without #, e.g., work, project)")
+					.addText((text) => {
+						text.setPlaceholder("work, project, meeting")
+							.setValue(customScope.includeTags.join(', '))
+							.onChange(async (value) => {
+								if (!this.plugin.settings.customAnalysisScope) {
+									this.plugin.settings.customAnalysisScope = { ...DEFAULT_SETTINGS.customAnalysisScope };
+								}
+								this.plugin.settings.customAnalysisScope.includeTags = value
+									.split(',')
+									.map(k => k.trim())
+									.filter(k => k.length > 0);
+								await this.plugin.saveSettings();
+							});
+					});
+
+				// Exclude Tags
+				new Setting(containerEl)
+					.setName("Exclude Tags")
+					.setDesc("Comma-separated tags to exclude from analysis (without #, e.g., personal, private)")
+					.addText((text) => {
+						text.setPlaceholder("personal, private, family")
+							.setValue(customScope.excludeTags.join(', '))
+							.onChange(async (value) => {
+								if (!this.plugin.settings.customAnalysisScope) {
+									this.plugin.settings.customAnalysisScope = { ...DEFAULT_SETTINGS.customAnalysisScope };
+								}
+								this.plugin.settings.customAnalysisScope.excludeTags = value
+									.split(',')
+									.map(k => k.trim())
+									.filter(k => k.length > 0);
+								await this.plugin.saveSettings();
+							});
+					});
+
+				// Include Folders
+				new Setting(containerEl)
+					.setName("Include Folders")
+					.setDesc("Comma-separated folder paths to include in analysis (e.g., Work Notes, Projects)")
+					.addText((text) => {
+						text.setPlaceholder("Work Notes, Projects, Meetings")
+							.setValue(customScope.includeFolders.join(', '))
+							.onChange(async (value) => {
+								if (!this.plugin.settings.customAnalysisScope) {
+									this.plugin.settings.customAnalysisScope = { ...DEFAULT_SETTINGS.customAnalysisScope };
+								}
+								this.plugin.settings.customAnalysisScope.includeFolders = value
+									.split(',')
+									.map(k => k.trim())
+									.filter(k => k.length > 0);
+								await this.plugin.saveSettings();
+							});
+					});
+
+				// Exclude Folders
+				new Setting(containerEl)
+					.setName("Exclude Folders")
+					.setDesc("Comma-separated folder paths to exclude from analysis (e.g., Personal, Private)")
+					.addText((text) => {
+						text.setPlaceholder("Personal, Private, Family")
+							.setValue(customScope.excludeFolders.join(', '))
+							.onChange(async (value) => {
+								if (!this.plugin.settings.customAnalysisScope) {
+									this.plugin.settings.customAnalysisScope = { ...DEFAULT_SETTINGS.customAnalysisScope };
+								}
+								this.plugin.settings.customAnalysisScope.excludeFolders = value
+									.split(',')
+									.map(k => k.trim())
+									.filter(k => k.length > 0);
+								await this.plugin.saveSettings();
+							});
+					});
+
+				// Scope Preview
+				const scopePreview = containerEl.createDiv({ cls: "setting-item-description" });
+				scopePreview.innerHTML = `
+					<strong>Custom Scope Preview:</strong><br>
+					<strong>Name:</strong> ${customScope.name || 'Unnamed'}<br>
+					<strong>Include Keywords:</strong> ${customScope.includeKeywords.length > 0 ? customScope.includeKeywords.join(', ') : 'None'}<br>
+					<strong>Exclude Keywords:</strong> ${customScope.excludeKeywords.length > 0 ? customScope.excludeKeywords.join(', ') : 'None'}<br>
+					<strong>Include Tags:</strong> ${customScope.includeTags.length > 0 ? customScope.includeTags.map(t => '#' + t).join(', ') : 'None'}<br>
+					<strong>Exclude Tags:</strong> ${customScope.excludeTags.length > 0 ? customScope.excludeTags.map(t => '#' + t).join(', ') : 'None'}<br>
+					<strong>Include Folders:</strong> ${customScope.includeFolders.length > 0 ? customScope.includeFolders.join(', ') : 'None'}<br>
+					<strong>Exclude Folders:</strong> ${customScope.excludeFolders.length > 0 ? customScope.excludeFolders.join(', ') : 'None'}
+				`;
+			}
+		}
+
 		// Advanced NLP Analysis Section
 		containerEl.createEl("h3", { text: "Advanced NLP Analysis" });
+
+		// Enable Analysis Scopes Feature Flag
+		new Setting(containerEl)
+			.setName("Enable Analysis Scopes (Beta)")
+			.setDesc("Enable analysis scope settings to focus on specific areas of your journal (work-only, custom filters, etc.)")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.enabledAnalysisScopes ?? false)
+					.onChange(async (value) => {
+						this.plugin.settings.enabledAnalysisScopes = value;
+						await this.plugin.saveSettings();
+						// Refresh to show/hide analysis scope settings
+						this.display();
+					})
+			);
 
 		// Enable Advanced NLP
 		new Setting(containerEl)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1042,6 +1042,24 @@ class JournalReflectionSettingTab extends PluginSettingTab {
 		this.plugin = plugin;
 	}
 
+	/**
+	 * Helper function to ensure customAnalysisScope is initialized
+	 * Reduces duplication in the settings UI
+	 */
+	private ensureCustomAnalysisScope(): void {
+		if (!this.plugin.settings.customAnalysisScope) {
+			this.plugin.settings.customAnalysisScope = {
+				name: DEFAULT_SETTINGS.customAnalysisScope!.name,
+				includeKeywords: [...DEFAULT_SETTINGS.customAnalysisScope!.includeKeywords],
+				excludeKeywords: [...DEFAULT_SETTINGS.customAnalysisScope!.excludeKeywords],
+				includeFolders: [...DEFAULT_SETTINGS.customAnalysisScope!.includeFolders],
+				excludeFolders: [...DEFAULT_SETTINGS.customAnalysisScope!.excludeFolders],
+				includeTags: [...DEFAULT_SETTINGS.customAnalysisScope!.includeTags],
+				excludeTags: [...DEFAULT_SETTINGS.customAnalysisScope!.excludeTags]
+			};
+		}
+	}
+
 	display(): void {
 		const { containerEl } = this;
 		containerEl.empty();
@@ -1297,7 +1315,8 @@ class JournalReflectionSettingTab extends PluginSettingTab {
 
 			// Custom Scope Settings (only show if custom is selected)
 			if (this.plugin.settings.analysisScope === 'custom') {
-				const customScope = this.plugin.settings.customAnalysisScope || DEFAULT_SETTINGS.customAnalysisScope;
+				this.ensureCustomAnalysisScope();
+				const customScope = this.plugin.settings.customAnalysisScope!;
 
 				// Custom Scope Name
 				new Setting(containerEl)
@@ -1307,10 +1326,8 @@ class JournalReflectionSettingTab extends PluginSettingTab {
 						text.setPlaceholder("e.g., Health & Wellness, Creative Projects")
 							.setValue(customScope.name)
 							.onChange(async (value) => {
-								if (!this.plugin.settings.customAnalysisScope) {
-									this.plugin.settings.customAnalysisScope = { ...DEFAULT_SETTINGS.customAnalysisScope };
-								}
-								this.plugin.settings.customAnalysisScope.name = value;
+								this.ensureCustomAnalysisScope();
+								this.plugin.settings.customAnalysisScope!.name = value;
 								await this.plugin.saveSettings();
 							});
 					});
@@ -1323,10 +1340,8 @@ class JournalReflectionSettingTab extends PluginSettingTab {
 						text.setPlaceholder("work, project, meeting, deadline")
 							.setValue(customScope.includeKeywords.join(', '))
 							.onChange(async (value) => {
-								if (!this.plugin.settings.customAnalysisScope) {
-									this.plugin.settings.customAnalysisScope = { ...DEFAULT_SETTINGS.customAnalysisScope };
-								}
-								this.plugin.settings.customAnalysisScope.includeKeywords = value
+								this.ensureCustomAnalysisScope();
+								this.plugin.settings.customAnalysisScope!.includeKeywords = value
 									.split(',')
 									.map(k => k.trim())
 									.filter(k => k.length > 0);
@@ -1342,10 +1357,8 @@ class JournalReflectionSettingTab extends PluginSettingTab {
 						text.setPlaceholder("personal, private, family")
 							.setValue(customScope.excludeKeywords.join(', '))
 							.onChange(async (value) => {
-								if (!this.plugin.settings.customAnalysisScope) {
-									this.plugin.settings.customAnalysisScope = { ...DEFAULT_SETTINGS.customAnalysisScope };
-								}
-								this.plugin.settings.customAnalysisScope.excludeKeywords = value
+								this.ensureCustomAnalysisScope();
+								this.plugin.settings.customAnalysisScope!.excludeKeywords = value
 									.split(',')
 									.map(k => k.trim())
 									.filter(k => k.length > 0);
@@ -1361,10 +1374,8 @@ class JournalReflectionSettingTab extends PluginSettingTab {
 						text.setPlaceholder("work, project, meeting")
 							.setValue(customScope.includeTags.join(', '))
 							.onChange(async (value) => {
-								if (!this.plugin.settings.customAnalysisScope) {
-									this.plugin.settings.customAnalysisScope = { ...DEFAULT_SETTINGS.customAnalysisScope };
-								}
-								this.plugin.settings.customAnalysisScope.includeTags = value
+								this.ensureCustomAnalysisScope();
+								this.plugin.settings.customAnalysisScope!.includeTags = value
 									.split(',')
 									.map(k => k.trim())
 									.filter(k => k.length > 0);
@@ -1380,10 +1391,8 @@ class JournalReflectionSettingTab extends PluginSettingTab {
 						text.setPlaceholder("personal, private, family")
 							.setValue(customScope.excludeTags.join(', '))
 							.onChange(async (value) => {
-								if (!this.plugin.settings.customAnalysisScope) {
-									this.plugin.settings.customAnalysisScope = { ...DEFAULT_SETTINGS.customAnalysisScope };
-								}
-								this.plugin.settings.customAnalysisScope.excludeTags = value
+								this.ensureCustomAnalysisScope();
+								this.plugin.settings.customAnalysisScope!.excludeTags = value
 									.split(',')
 									.map(k => k.trim())
 									.filter(k => k.length > 0);
@@ -1399,10 +1408,8 @@ class JournalReflectionSettingTab extends PluginSettingTab {
 						text.setPlaceholder("Work Notes, Projects, Meetings")
 							.setValue(customScope.includeFolders.join(', '))
 							.onChange(async (value) => {
-								if (!this.plugin.settings.customAnalysisScope) {
-									this.plugin.settings.customAnalysisScope = { ...DEFAULT_SETTINGS.customAnalysisScope };
-								}
-								this.plugin.settings.customAnalysisScope.includeFolders = value
+								this.ensureCustomAnalysisScope();
+								this.plugin.settings.customAnalysisScope!.includeFolders = value
 									.split(',')
 									.map(k => k.trim())
 									.filter(k => k.length > 0);
@@ -1418,10 +1425,8 @@ class JournalReflectionSettingTab extends PluginSettingTab {
 						text.setPlaceholder("Personal, Private, Family")
 							.setValue(customScope.excludeFolders.join(', '))
 							.onChange(async (value) => {
-								if (!this.plugin.settings.customAnalysisScope) {
-									this.plugin.settings.customAnalysisScope = { ...DEFAULT_SETTINGS.customAnalysisScope };
-								}
-								this.plugin.settings.customAnalysisScope.excludeFolders = value
+								this.ensureCustomAnalysisScope();
+								this.plugin.settings.customAnalysisScope!.excludeFolders = value
 									.split(',')
 									.map(k => k.trim())
 									.filter(k => k.length > 0);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1114,7 +1114,9 @@ class JournalReflectionSettingTab extends PluginSettingTab {
 		if (!this.plugin.settings.encryptionEnabled) {
 			const warningEl = containerEl.createDiv({ cls: "setting-item-description" });
 			warningEl.style.color = "var(--text-warning)";
-			warningEl.innerHTML = "⚠️ <strong>Security Warning:</strong> Your API key is stored in plain text. Consider enabling encryption for better security.";
+			warningEl.createSpan({ text: "⚠️ " });
+			warningEl.createEl("strong", { text: "Security Warning:" });
+			warningEl.createSpan({ text: " Your API key is stored in plain text. Consider enabling encryption for better security." });
 		}
 		
 		containerEl.createEl("h3", { text: "AI Configuration" });
@@ -1436,16 +1438,35 @@ class JournalReflectionSettingTab extends PluginSettingTab {
 
 				// Scope Preview
 				const scopePreview = containerEl.createDiv({ cls: "setting-item-description" });
-				scopePreview.innerHTML = `
-					<strong>Custom Scope Preview:</strong><br>
-					<strong>Name:</strong> ${customScope.name || 'Unnamed'}<br>
-					<strong>Include Keywords:</strong> ${customScope.includeKeywords.length > 0 ? customScope.includeKeywords.join(', ') : 'None'}<br>
-					<strong>Exclude Keywords:</strong> ${customScope.excludeKeywords.length > 0 ? customScope.excludeKeywords.join(', ') : 'None'}<br>
-					<strong>Include Tags:</strong> ${customScope.includeTags.length > 0 ? customScope.includeTags.map(t => '#' + t).join(', ') : 'None'}<br>
-					<strong>Exclude Tags:</strong> ${customScope.excludeTags.length > 0 ? customScope.excludeTags.map(t => '#' + t).join(', ') : 'None'}<br>
-					<strong>Include Folders:</strong> ${customScope.includeFolders.length > 0 ? customScope.includeFolders.join(', ') : 'None'}<br>
-					<strong>Exclude Folders:</strong> ${customScope.excludeFolders.length > 0 ? customScope.excludeFolders.join(', ') : 'None'}
-				`;
+				scopePreview.createEl("strong", { text: "Custom Scope Preview:" });
+				scopePreview.createEl("br");
+				
+				scopePreview.createEl("strong", { text: "Name: " });
+				scopePreview.createSpan({ text: customScope.name || 'Unnamed' });
+				scopePreview.createEl("br");
+				
+				scopePreview.createEl("strong", { text: "Include Keywords: " });
+				scopePreview.createSpan({ text: customScope.includeKeywords.length > 0 ? customScope.includeKeywords.join(', ') : 'None' });
+				scopePreview.createEl("br");
+				
+				scopePreview.createEl("strong", { text: "Exclude Keywords: " });
+				scopePreview.createSpan({ text: customScope.excludeKeywords.length > 0 ? customScope.excludeKeywords.join(', ') : 'None' });
+				scopePreview.createEl("br");
+				
+				scopePreview.createEl("strong", { text: "Include Tags: " });
+				scopePreview.createSpan({ text: customScope.includeTags.length > 0 ? customScope.includeTags.map(t => '#' + t).join(', ') : 'None' });
+				scopePreview.createEl("br");
+				
+				scopePreview.createEl("strong", { text: "Exclude Tags: " });
+				scopePreview.createSpan({ text: customScope.excludeTags.length > 0 ? customScope.excludeTags.map(t => '#' + t).join(', ') : 'None' });
+				scopePreview.createEl("br");
+				
+				scopePreview.createEl("strong", { text: "Include Folders: " });
+				scopePreview.createSpan({ text: customScope.includeFolders.length > 0 ? customScope.includeFolders.join(', ') : 'None' });
+				scopePreview.createEl("br");
+				
+				scopePreview.createEl("strong", { text: "Exclude Folders: " });
+				scopePreview.createSpan({ text: customScope.excludeFolders.length > 0 ? customScope.excludeFolders.join(', ') : 'None' });
 			}
 		}
 
@@ -1571,14 +1592,27 @@ class JournalReflectionSettingTab extends PluginSettingTab {
 
 			// NLP Features Info
 			const infoEl = containerEl.createDiv({ cls: "setting-item-description" });
-			infoEl.innerHTML = `
-				<strong>Advanced NLP Features:</strong><br>
-				• <strong>Productivity Theme Extraction:</strong> Identifies recurring themes in your work<br>
-				• <strong>Blocker Detection:</strong> Spots procrastination, time management, and workflow issues<br>
-				• <strong>Multi-dimensional Sentiment:</strong> Analyzes emotions, arousal levels, and productivity mood<br>
-				• <strong>Context-aware Analysis:</strong> Understands the nuances of your writing style<br>
-				• <strong>Pattern Correlation:</strong> Connects productivity patterns with mood and activities
-			`;
+			infoEl.createEl("strong", { text: "Advanced NLP Features:" });
+			infoEl.createEl("br");
+			infoEl.createSpan({ text: "• " });
+			infoEl.createEl("strong", { text: "Productivity Theme Extraction:" });
+			infoEl.createSpan({ text: " Identifies recurring themes in your work" });
+			infoEl.createEl("br");
+			infoEl.createSpan({ text: "• " });
+			infoEl.createEl("strong", { text: "Blocker Detection:" });
+			infoEl.createSpan({ text: " Spots procrastination, time management, and workflow issues" });
+			infoEl.createEl("br");
+			infoEl.createSpan({ text: "• " });
+			infoEl.createEl("strong", { text: "Multi-dimensional Sentiment:" });
+			infoEl.createSpan({ text: " Analyzes emotions, arousal levels, and productivity mood" });
+			infoEl.createEl("br");
+			infoEl.createSpan({ text: "• " });
+			infoEl.createEl("strong", { text: "Context-aware Analysis:" });
+			infoEl.createSpan({ text: " Understands the nuances of your writing style" });
+			infoEl.createEl("br");
+			infoEl.createSpan({ text: "• " });
+			infoEl.createEl("strong", { text: "Pattern Correlation:" });
+			infoEl.createSpan({ text: " Connects productivity patterns with mood and activities" });
 		}
 	}
 

--- a/src/services/FileOperationsService.ts
+++ b/src/services/FileOperationsService.ts
@@ -578,9 +578,16 @@ ${backlinks}
         }
 
         if (customScope.excludeFolders.length > 0) {
-            const isInExcludedFolder = customScope.excludeFolders.some(folder => 
-                filePathLower.includes(folder.toLowerCase())
-            );
+            const filePathSegments = file.path.split(/[\/]/).map(seg => seg.toLowerCase());
+            const isInExcludedFolder = customScope.excludeFolders.some(folder => {
+                const folderSegments = folder.split(/[\/]/).map(seg => seg.toLowerCase());
+                // Check if folderSegments is a prefix of filePathSegments
+                if (folderSegments.length > filePathSegments.length) return false;
+                for (let i = 0; i < folderSegments.length; i++) {
+                    if (filePathSegments[i] !== folderSegments[i]) return false;
+                }
+                return true;
+            });
             if (isInExcludedFolder) {
                 return false;
             }
@@ -598,9 +605,10 @@ ${backlinks}
         }
 
         if (customScope.excludeTags.length > 0) {
-            const hasExcludedTag = customScope.excludeTags.some(tag => 
-                contentLower.includes(`#${tag.toLowerCase()}`)
-            );
+            const hasExcludedTag = customScope.excludeTags.some(tag => {
+                const tagPattern = new RegExp(`\\B#${tag}\\b`, 'i');
+                return tagPattern.test(content);
+            });
             if (hasExcludedTag) {
                 return false;
             }

--- a/src/services/FileOperationsService.ts
+++ b/src/services/FileOperationsService.ts
@@ -564,9 +564,16 @@ ${backlinks}
 
         // Check folder inclusion/exclusion
         if (customScope.includeFolders.length > 0) {
-            const isInIncludedFolder = customScope.includeFolders.some(folder => 
-                filePathLower.includes(folder.toLowerCase())
-            );
+            const filePathSegments = file.path.split(/[\\/]/).map(seg => seg.toLowerCase());
+            const isInIncludedFolder = customScope.includeFolders.some(folder => {
+                const folderSegments = folder.split(/[\\/]/).map(seg => seg.toLowerCase());
+                // Check if folderSegments is a prefix of filePathSegments
+                if (folderSegments.length > filePathSegments.length) return false;
+                for (let i = 0; i < folderSegments.length; i++) {
+                    if (filePathSegments[i] !== folderSegments[i]) return false;
+                }
+                return true;
+            });
             if (!isInIncludedFolder) {
                 return false;
             }

--- a/src/services/FileOperationsService.ts
+++ b/src/services/FileOperationsService.ts
@@ -12,6 +12,18 @@ export interface FileOperationsConfig {
     excludePrivate: boolean;
     periodicNoteFolders: string[];
     reflectionFolder: string;
+    // Analysis scope settings
+    enabledAnalysisScopes?: boolean;
+    analysisScope?: 'whole-life' | 'work-only' | 'custom';
+    customAnalysisScope?: {
+        name: string;
+        includeKeywords: string[];
+        excludeKeywords: string[];
+        includeFolders: string[];
+        excludeFolders: string[];
+        includeTags: string[];
+        excludeTags: string[];
+    };
 }
 
 /**
@@ -96,6 +108,11 @@ export class FileOperationsService extends BaseService {
 
                         // Skip if private (contains #private tag)
                         if (this.config.excludePrivate && content.includes("#private")) {
+                            continue;
+                        }
+
+                        // Apply analysis scope filtering if enabled
+                        if (this.config.enabledAnalysisScopes && !this.isFileInAnalysisScope(file, content)) {
                             continue;
                         }
 
@@ -459,6 +476,150 @@ ${backlinks}
             console.error('FileOperationsService initialization failed:', error);
             throw error;
         }
+    }
+
+    /**
+     * Check if a file and its content should be included in analysis scope
+     * 
+     * @param file - The file to check
+     * @param content - The file content
+     * @returns True if the file should be included in analysis
+     */
+    private isFileInAnalysisScope(file: TFile, content: string): boolean {
+        if (!this.config.enabledAnalysisScopes) {
+            return true; // No scope filtering
+        }
+
+        const scope = this.config.analysisScope || 'whole-life';
+
+        switch (scope) {
+            case 'whole-life':
+                return true;
+            
+            case 'work-only':
+                return this.isWorkRelatedContent(file, content);
+            
+            case 'custom':
+                return this.isCustomScopeContent(file, content);
+            
+            default:
+                return true;
+        }
+    }
+
+    /**
+     * Check if content is work-related (for work-only scope)
+     * 
+     * @param file - The file to check
+     * @param content - The file content
+     * @returns True if content is work-related
+     */
+    private isWorkRelatedContent(file: TFile, content: string): boolean {
+        const workKeywords = [
+            'work', 'job', 'project', 'meeting', 'task', 'deadline',
+            'client', 'team', 'boss', 'colleague', 'office', 'business',
+            'development', 'coding', 'programming', 'bug', 'feature',
+            'review', 'standup', 'sprint', 'agile', 'scrum'
+        ];
+
+        const workTags = ['work', 'job', 'project', 'meeting', 'task', 'business'];
+        
+        const contentLower = content.toLowerCase();
+        const filePathLower = file.path.toLowerCase();
+
+        // Check for work keywords in content
+        const hasWorkKeywords = workKeywords.some(keyword => 
+            contentLower.includes(keyword)
+        );
+
+        // Check for work tags
+        const hasWorkTags = workTags.some(tag => 
+            contentLower.includes(`#${tag}`)
+        );
+
+        // Check if file is in work-related folders
+        const isInWorkFolder = filePathLower.includes('work') || 
+                              filePathLower.includes('job') || 
+                              filePathLower.includes('project') ||
+                              filePathLower.includes('business');
+
+        return hasWorkKeywords || hasWorkTags || isInWorkFolder;
+    }
+
+    /**
+     * Check if content matches custom scope criteria
+     * 
+     * @param file - The file to check
+     * @param content - The file content
+     * @returns True if content matches custom scope
+     */
+    private isCustomScopeContent(file: TFile, content: string): boolean {
+        const customScope = this.config.customAnalysisScope;
+        if (!customScope) {
+            return true; // No custom scope defined, include all
+        }
+
+        const contentLower = content.toLowerCase();
+        const filePathLower = file.path.toLowerCase();
+
+        // Check folder inclusion/exclusion
+        if (customScope.includeFolders.length > 0) {
+            const isInIncludedFolder = customScope.includeFolders.some(folder => 
+                filePathLower.includes(folder.toLowerCase())
+            );
+            if (!isInIncludedFolder) {
+                return false;
+            }
+        }
+
+        if (customScope.excludeFolders.length > 0) {
+            const isInExcludedFolder = customScope.excludeFolders.some(folder => 
+                filePathLower.includes(folder.toLowerCase())
+            );
+            if (isInExcludedFolder) {
+                return false;
+            }
+        }
+
+        // Check tag inclusion/exclusion
+        if (customScope.includeTags.length > 0) {
+            const hasIncludedTag = customScope.includeTags.some(tag => 
+                contentLower.includes(`#${tag.toLowerCase()}`)
+            );
+            if (!hasIncludedTag) {
+                return false;
+            }
+        }
+
+        if (customScope.excludeTags.length > 0) {
+            const hasExcludedTag = customScope.excludeTags.some(tag => 
+                contentLower.includes(`#${tag.toLowerCase()}`)
+            );
+            if (hasExcludedTag) {
+                return false;
+            }
+        }
+
+        // Check keyword inclusion/exclusion
+        if (customScope.includeKeywords.length > 0) {
+            const hasIncludedKeyword = customScope.includeKeywords.some(keyword => 
+                contentLower.includes(keyword.toLowerCase())
+            );
+            if (!hasIncludedKeyword) {
+                return false;
+            }
+        }
+
+        if (customScope.excludeKeywords.length > 0) {
+            const hasExcludedKeyword = customScope.excludeKeywords.some(keyword => 
+                contentLower.includes(keyword.toLowerCase())
+            );
+            if (hasExcludedKeyword) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/services/FileOperationsService.ts
+++ b/src/services/FileOperationsService.ts
@@ -610,9 +610,13 @@ ${backlinks}
 
         // Check keyword inclusion/exclusion
         if (customScope.includeKeywords.length > 0) {
-            const hasIncludedKeyword = customScope.includeKeywords.some(keyword => 
-                contentLower.includes(keyword.toLowerCase())
-            );
+            const hasIncludedKeyword = customScope.includeKeywords.some(keyword => {
+                // Escape special regex characters in the keyword
+                const escapedKeyword = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                // Create a regex to match the whole word, case-insensitive
+                const regex = new RegExp(`\\b${escapedKeyword}\\b`, 'i');
+                return regex.test(content);
+            });
             if (!hasIncludedKeyword) {
                 return false;
             }

--- a/src/services/FileOperationsService.ts
+++ b/src/services/FileOperationsService.ts
@@ -532,10 +532,9 @@ ${backlinks}
             contentLower.includes(keyword)
         );
 
-        // Check for work tags
-        const hasWorkTags = workTags.some(tag => 
-            contentLower.includes(`#${tag}`)
-        );
+        // Check for work tags using regex to match whole tags
+        const workTagsPattern = new RegExp(`#(${workTags.join('|')})\\b`, 'i');
+        const hasWorkTags = workTagsPattern.test(content);
 
         // Check if file is in work-related folders
         const isInWorkFolder = filePathLower.includes('work') || 

--- a/src/services/FileOperationsService.ts
+++ b/src/services/FileOperationsService.ts
@@ -536,11 +536,10 @@ ${backlinks}
         const workTagsPattern = new RegExp(`#(${workTags.join('|')})\\b`, 'i');
         const hasWorkTags = workTagsPattern.test(content);
 
-        // Check if file is in work-related folders
-        const isInWorkFolder = filePathLower.includes('work') || 
-                              filePathLower.includes('job') || 
-                              filePathLower.includes('project') ||
-                              filePathLower.includes('business');
+        // Check if file is in work-related folders (exact match on folder names)
+        const workFolders = ['work', 'job', 'project', 'business'];
+        const pathSegments = filePathLower.split(/[\\/]/); // Handles both '/' and '\' as separators
+        const isInWorkFolder = pathSegments.some(segment => workFolders.includes(segment));
 
         return hasWorkKeywords || hasWorkTags || isInWorkFolder;
     }

--- a/src/services/FileOperationsService.ts
+++ b/src/services/FileOperationsService.ts
@@ -611,9 +611,13 @@ ${backlinks}
         }
 
         if (customScope.excludeKeywords.length > 0) {
-            const hasExcludedKeyword = customScope.excludeKeywords.some(keyword => 
-                contentLower.includes(keyword.toLowerCase())
-            );
+            const hasExcludedKeyword = customScope.excludeKeywords.some(keyword => {
+                // Escape special regex characters in the keyword
+                const escapedKeyword = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                // Create a regex with word boundaries, case-insensitive
+                const regex = new RegExp(`\\b${escapedKeyword}\\b`, 'i');
+                return regex.test(contentLower);
+            });
             if (hasExcludedKeyword) {
                 return false;
             }

--- a/src/services/FileOperationsService.ts
+++ b/src/services/FileOperationsService.ts
@@ -583,9 +583,10 @@ ${backlinks}
 
         // Check tag inclusion/exclusion
         if (customScope.includeTags.length > 0) {
-            const hasIncludedTag = customScope.includeTags.some(tag => 
-                contentLower.includes(`#${tag.toLowerCase()}`)
-            );
+            const hasIncludedTag = customScope.includeTags.some(tag => {
+                const tagPattern = new RegExp(`\\B#${tag}\\b`, 'i');
+                return tagPattern.test(content);
+            });
             if (!hasIncludedTag) {
                 return false;
             }

--- a/tests/AnalysisScope.test.ts
+++ b/tests/AnalysisScope.test.ts
@@ -1,0 +1,382 @@
+// tests/AnalysisScope.test.ts
+
+import { TFile } from 'obsidian';
+import { FileOperationsService, FileOperationsConfig } from '../src/services/FileOperationsService';
+import { ErrorHandlingService } from '../src/services/ErrorHandlingService';
+
+// Mock Obsidian components
+jest.mock('obsidian', () => ({
+    App: jest.fn(),
+    Plugin: jest.fn(),
+    TFile: jest.fn(),
+    TFolder: jest.fn(),
+    moment: jest.fn(() => ({
+        subtract: jest.fn().mockReturnThis(),
+        isAfter: jest.fn().mockReturnValue(true),
+        isValid: jest.fn().mockReturnValue(true),
+        format: jest.fn().mockReturnValue('2024-01-01')
+    }))
+}));
+
+describe('Analysis Scope Functionality', () => {
+    let mockApp: any;
+    let mockErrorHandler: ErrorHandlingService;
+    let fileOpsService: FileOperationsService;
+
+    beforeEach(() => {
+        mockApp = {
+            vault: {
+                read: jest.fn(),
+                getMarkdownFiles: jest.fn().mockReturnValue([]),
+                getAbstractFileByPath: jest.fn(),
+                createFolder: jest.fn(),
+                create: jest.fn(),
+                adapter: {
+                    exists: jest.fn().mockResolvedValue(false)
+                }
+            }
+        };
+
+        mockErrorHandler = {
+            executeWithRetry: jest.fn((fn) => fn()),
+            handleError: jest.fn()
+        } as any;
+    });
+
+    describe('Analysis Scope Settings', () => {
+        it('should default to whole-life scope when not enabled', () => {
+            const config: FileOperationsConfig = {
+                daysToInclude: 7,
+                excludePrivate: true,
+                periodicNoteFolders: [],
+                reflectionFolder: 'Summaries',
+                enabledAnalysisScopes: false,
+                analysisScope: 'whole-life'
+            };
+
+            fileOpsService = new FileOperationsService(mockApp, config, mockErrorHandler);
+            expect(fileOpsService).toBeDefined();
+        });
+
+        it('should handle work-only scope configuration', () => {
+            const config: FileOperationsConfig = {
+                daysToInclude: 7,
+                excludePrivate: true,
+                periodicNoteFolders: [],
+                reflectionFolder: 'Summaries',
+                enabledAnalysisScopes: true,
+                analysisScope: 'work-only'
+            };
+
+            fileOpsService = new FileOperationsService(mockApp, config, mockErrorHandler);
+            expect(fileOpsService).toBeDefined();
+        });
+
+        it('should handle custom scope configuration', () => {
+            const config: FileOperationsConfig = {
+                daysToInclude: 7,
+                excludePrivate: true,
+                periodicNoteFolders: [],
+                reflectionFolder: 'Summaries',
+                enabledAnalysisScopes: true,
+                analysisScope: 'custom',
+                customAnalysisScope: {
+                    name: 'Test Scope',
+                    includeKeywords: ['test', 'development'],
+                    excludeKeywords: ['personal'],
+                    includeFolders: ['Work'],
+                    excludeFolders: ['Personal'],
+                    includeTags: ['work'],
+                    excludeTags: ['private']
+                }
+            };
+
+            fileOpsService = new FileOperationsService(mockApp, config, mockErrorHandler);
+            expect(fileOpsService).toBeDefined();
+        });
+    });
+
+    describe('Work-Only Scope Filtering', () => {
+        beforeEach(async () => {
+            const config: FileOperationsConfig = {
+                daysToInclude: 7,
+                excludePrivate: true,
+                periodicNoteFolders: [],
+                reflectionFolder: 'Summaries',
+                enabledAnalysisScopes: true,
+                analysisScope: 'work-only'
+            };
+
+            fileOpsService = new FileOperationsService(mockApp, config, mockErrorHandler);
+            await fileOpsService.initialize();
+        });
+
+        it('should include work-related content with work keywords', async () => {
+            const mockFile = {
+                path: 'daily/2024-01-01.md',
+                basename: '2024-01-01'
+            } as TFile;
+
+            const workContent = 'Today I had a meeting with the team about the new project deadline.';
+            mockApp.vault.read.mockResolvedValue(workContent);
+
+            const result = await fileOpsService.getNotesContent([mockFile]);
+            expect(result).toContain('2024-01-01');
+            expect(result).toContain(workContent);
+        });
+
+        it('should include work-related content with work tags', async () => {
+            const mockFile = {
+                path: 'daily/2024-01-01.md',
+                basename: '2024-01-01'
+            } as TFile;
+
+            const workContent = 'Working on the new feature today #work #project';
+            mockApp.vault.read.mockResolvedValue(workContent);
+
+            const result = await fileOpsService.getNotesContent([mockFile]);
+            expect(result).toContain('2024-01-01');
+            expect(result).toContain(workContent);
+        });
+
+        it('should include work-related content from work folders', async () => {
+            const mockFile = {
+                path: 'work/daily/2024-01-01.md',
+                basename: '2024-01-01'
+            } as TFile;
+
+            const content = 'Today was a good day.';
+            mockApp.vault.read.mockResolvedValue(content);
+
+            const result = await fileOpsService.getNotesContent([mockFile]);
+            expect(result).toContain('2024-01-01');
+            expect(result).toContain(content);
+        });
+
+        it('should exclude non-work content', async () => {
+            const mockFile = {
+                path: 'daily/2024-01-01.md',
+                basename: '2024-01-01'
+            } as TFile;
+
+            const personalContent = 'Went to the movies with friends. Had a great time at the restaurant.';
+            mockApp.vault.read.mockResolvedValue(personalContent);
+
+            const result = await fileOpsService.getNotesContent([mockFile]);
+            expect(result).not.toContain(personalContent);
+        });
+    });
+
+    describe('Custom Scope Filtering', () => {
+        beforeEach(async () => {
+            const config: FileOperationsConfig = {
+                daysToInclude: 7,
+                excludePrivate: true,
+                periodicNoteFolders: [],
+                reflectionFolder: 'Summaries',
+                enabledAnalysisScopes: true,
+                analysisScope: 'custom',
+                customAnalysisScope: {
+                    name: 'Health & Wellness',
+                    includeKeywords: ['health', 'exercise', 'nutrition'],
+                    excludeKeywords: ['work', 'meeting'],
+                    includeFolders: [],
+                    excludeFolders: ['Work'],
+                    includeTags: [],
+                    excludeTags: ['work', 'business']
+                }
+            };
+
+            fileOpsService = new FileOperationsService(mockApp, config, mockErrorHandler);
+            await fileOpsService.initialize();
+        });
+
+        it('should include content with included keywords', async () => {
+            const mockFile = {
+                path: 'daily/2024-01-01.md',
+                basename: '2024-01-01'
+            } as TFile;
+
+            const healthContent = 'Did a great exercise today and focused on nutrition.';
+            mockApp.vault.read.mockResolvedValue(healthContent);
+
+            const result = await fileOpsService.getNotesContent([mockFile]);
+            expect(result).toContain('2024-01-01');
+            expect(result).toContain(healthContent);
+        });
+
+        it('should include content with included tags', async () => {
+            // Create a service with only tag filtering
+            const tagOnlyConfig: FileOperationsConfig = {
+                daysToInclude: 7,
+                excludePrivate: true,
+                periodicNoteFolders: [],
+                reflectionFolder: 'Summaries',
+                enabledAnalysisScopes: true,
+                analysisScope: 'custom',
+                customAnalysisScope: {
+                    name: 'Health Tags',
+                    includeKeywords: [],
+                    excludeKeywords: [],
+                    includeFolders: [],
+                    excludeFolders: [],
+                    includeTags: ['health', 'fitness'],
+                    excludeTags: []
+                }
+            };
+
+            const tagService = new FileOperationsService(mockApp, tagOnlyConfig, mockErrorHandler);
+            await tagService.initialize();
+
+            const mockFile = {
+                path: 'daily/2024-01-01.md',
+                basename: '2024-01-01'
+            } as TFile;
+
+            const healthContent = 'Great day for fitness #health #fitness';
+            mockApp.vault.read.mockResolvedValue(healthContent);
+
+            const result = await tagService.getNotesContent([mockFile]);
+            expect(result).toContain('2024-01-01');
+            expect(result).toContain(healthContent);
+        });
+
+        it('should include content from included folders', async () => {
+            // Create a service with only folder filtering
+            const folderOnlyConfig: FileOperationsConfig = {
+                daysToInclude: 7,
+                excludePrivate: true,
+                periodicNoteFolders: [],
+                reflectionFolder: 'Summaries',
+                enabledAnalysisScopes: true,
+                analysisScope: 'custom',
+                customAnalysisScope: {
+                    name: 'Health Folders',
+                    includeKeywords: [],
+                    excludeKeywords: [],
+                    includeFolders: ['Health'],
+                    excludeFolders: [],
+                    includeTags: [],
+                    excludeTags: []
+                }
+            };
+
+            const folderService = new FileOperationsService(mockApp, folderOnlyConfig, mockErrorHandler);
+            await folderService.initialize();
+
+            const mockFile = {
+                path: 'Health/daily/2024-01-01.md',
+                basename: '2024-01-01'
+            } as TFile;
+
+            const content = 'Today was a good day.';
+            mockApp.vault.read.mockResolvedValue(content);
+
+            const result = await folderService.getNotesContent([mockFile]);
+            expect(result).toContain('2024-01-01');
+            expect(result).toContain(content);
+        });
+
+        it('should exclude content with excluded keywords', async () => {
+            const mockFile = {
+                path: 'daily/2024-01-01.md',
+                basename: '2024-01-01'
+            } as TFile;
+
+            const workContent = 'Had a work meeting today about the project.';
+            mockApp.vault.read.mockResolvedValue(workContent);
+
+            const result = await fileOpsService.getNotesContent([mockFile]);
+            expect(result).not.toContain(workContent);
+        });
+
+        it('should exclude content with excluded tags', async () => {
+            const mockFile = {
+                path: 'daily/2024-01-01.md',
+                basename: '2024-01-01'
+            } as TFile;
+
+            const workContent = 'Working on the project #work #business';
+            mockApp.vault.read.mockResolvedValue(workContent);
+
+            const result = await fileOpsService.getNotesContent([mockFile]);
+            expect(result).not.toContain(workContent);
+        });
+
+        it('should exclude content from excluded folders', async () => {
+            const mockFile = {
+                path: 'Work/daily/2024-01-01.md',
+                basename: '2024-01-01'
+            } as TFile;
+
+            const content = 'Today was a good day.';
+            mockApp.vault.read.mockResolvedValue(content);
+
+            const result = await fileOpsService.getNotesContent([mockFile]);
+            expect(result).not.toContain(content);
+        });
+    });
+
+    describe('Scope Integration', () => {
+        it('should bypass scope filtering when scopes are disabled', async () => {
+            const config: FileOperationsConfig = {
+                daysToInclude: 7,
+                excludePrivate: true,
+                periodicNoteFolders: [],
+                reflectionFolder: 'Summaries',
+                enabledAnalysisScopes: false,
+                analysisScope: 'work-only'
+            };
+
+            fileOpsService = new FileOperationsService(mockApp, config, mockErrorHandler);
+            await fileOpsService.initialize();
+
+            const mockFile = {
+                path: 'daily/2024-01-01.md',
+                basename: '2024-01-01'
+            } as TFile;
+
+            const personalContent = 'Went to the movies with friends.';
+            mockApp.vault.read.mockResolvedValue(personalContent);
+
+            const result = await fileOpsService.getNotesContent([mockFile]);
+            expect(result).toContain('2024-01-01');
+            expect(result).toContain(personalContent);
+        });
+
+        it('should handle empty custom scope gracefully', async () => {
+            const config: FileOperationsConfig = {
+                daysToInclude: 7,
+                excludePrivate: true,
+                periodicNoteFolders: [],
+                reflectionFolder: 'Summaries',
+                enabledAnalysisScopes: true,
+                analysisScope: 'custom',
+                customAnalysisScope: {
+                    name: '',
+                    includeKeywords: [],
+                    excludeKeywords: [],
+                    includeFolders: [],
+                    excludeFolders: [],
+                    includeTags: [],
+                    excludeTags: []
+                }
+            };
+
+            fileOpsService = new FileOperationsService(mockApp, config, mockErrorHandler);
+            await fileOpsService.initialize();
+
+            const mockFile = {
+                path: 'daily/2024-01-01.md',
+                basename: '2024-01-01'
+            } as TFile;
+
+            const content = 'Any content should be included.';
+            mockApp.vault.read.mockResolvedValue(content);
+
+            const result = await fileOpsService.getNotesContent([mockFile]);
+            expect(result).toContain('2024-01-01');
+            expect(result).toContain(content);
+        });
+    });
+});


### PR DESCRIPTION
## Summary by Sourcery

Add analysis scope functionality to the journal reflection plugin, including new settings in the UI and corresponding filtering logic in the file operations service.

New Features:
- Introduce an "Enable Analysis Scopes" feature flag with options for whole-life, work-only, or custom scopes
- Add custom analysis scope settings in the plugin UI to define include/exclude keywords, tags, and folders
- Integrate analysis scope filtering in FileOperationsService to include or exclude files based on the selected scope

Enhancements:
- Refactor security warning and advanced NLP feature descriptions to use createEl/createSpan instead of innerHTML

Tests:
- Add tests for analysis scope filtering logic