### PR TITLE
fix: export Logger utilities from services index

### DIFF
--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -20,3 +20,5 @@ export type { ErrorHandlingConfig, ErrorContext, ErrorHandlerOptions } from "./E
 export { RetrospectError, ErrorType, ErrorCode } from "./ErrorHandlingService";
 export { NLPAnalysisService } from "./NLPAnalysisService";
 export type { ProductivityTheme, BlockerPattern, SentimentAnalysis, TextPreprocessingResult, NLPAnalysisConfig } from "./NLPAnalysisService";
+export { Logger, createLogger } from "./Logger";
+export type { LogLevel, LogContext, LogErrorContext } from "./Logger";


### PR DESCRIPTION
## Summary
- Export Logger class and createLogger function from services/index.ts
- Export related types (LogLevel, LogContext, LogErrorContext) for complete type safety
- Fixes dead code issue identified in codebase analysis where Logger utilities were available internally but not exported for external use

## Changes Made
- Added exports for `Logger` and `createLogger` from `./Logger`
- Added type exports for `LogLevel`, `LogContext`, and `LogErrorContext`
- Enables external consumers to access logging functionality that was previously only available to internal services

## Test Plan
- [x] All existing tests pass (318/318)
- [x] No breaking changes to existing functionality
- [x] Logger utilities are now properly exported and accessible

This addresses the dead code analysis finding where Logger utilities were implemented but not accessible to external consumers.

🤖 Generated with [Claude Code](https://claude.ai/code)